### PR TITLE
Release as 0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ var servers = css({
       key: fs.readFileSync('./wss_server.key'),
       cert: fs.readFileSync('./wss_server.crt')
     }
+  },
+  s4: {
+    attach: existingHttpServer
   }
 }, {
   ssl: {

--- a/tests.js
+++ b/tests.js
@@ -2,6 +2,7 @@ var assert = require('assert');
 var fs = require('fs');
 var net = require('net');
 var tls = require('tls');
+var http = require('http');
 var ws = require('ws');
 
 var css = require('./index');
@@ -145,6 +146,22 @@ describe('create-stream-server', function(){
 
     servers.listen(function(){
       servers.close(function(){
+        done();
+      });
+    });
+  });
+
+  it('should allow attaching ws servers to an existing http server', function(done) {
+    var httpServer = http.createServer();
+
+    var servers = css({
+      s3: {
+        attach: httpServer
+      }
+    }, function(){});
+
+    servers.listen(function () {
+      servers.close(function () {
         done();
       });
     });


### PR DESCRIPTION
I think 0.0.1 is a really bad version number, as it does not allow ~ dependencies, e.g. we cannot deliver a bugfix that is automatically picked up by dependents.
